### PR TITLE
Added more detail to dell warranty

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [Device42](http://www.device42.com) is a comprehensive data center inventory management and IP Address management software that integrates centralized password management, impact charts and applications mappings with IT asset management.
 
 ##  Intro
-This script checks warranty status for Dell, HP and IBM manufactured devices stored in Device42. 
+This script checks warranty status for Dell, HP and IBM manufactured devices stored in Device42.
 Note: Currently works only for Dell
 
 ##Prerequisites
@@ -13,6 +13,18 @@ In order for this script to check warranty status of the device, the device must
 - Device42 Hardware model must have "Dell" in it's manufacturer data.
 - Device42 Serial number must be set to Dell's device serial number.
 - Dell's API key can be obtained by filling the on-boarding form. Please, follow the instructions from this ppt file: http://en.community.dell.com/dell-groups/supportapisgroup/m/mediagallery/20428185
+
+## Changes
+- Moved from just showing last date to showing all warranties and services found in the api call
+-	Comparison on existence of registration per purchase/support info (per line on the order) based on serial, line contract id and contract end date
+- Moved from querying ALL devices to just querying the devices from the vendor itself (so skipping virtual machines and other manufacturers)
+- using offset per 500 requests instead of doing a full request of all devices
+- brief pause per api call to prevent blockage at the api request site (1 second pause per api call)
+- making a remark if the session for the api call is unauthorized (http code 401)
+
+## Plans
+- move from individual api calls per serial to requesting warranty information for a list of systems at once, therefore reducing the amount of api calls towards the manufacturer
+-	Include life_cycle event to register the purchase date. Unfortunately it can’t can done now, as I can’t easily compare purchases with the information found at dell. The life_cycle event doesn’t give back the serial, only the devicename. It would be nice if the serial_no could be added to the output of GET /api/1.0/lifecycle_event/
 
 ##Gotchas
 If either hardware model or serial # is missing, warranty status won't be checked for device.
@@ -26,8 +38,3 @@ Set required parameters in warranty.cfg file and run warranty_dell.py script:
 ## Compatibility
 * Script runs on Linux and Windows
 * Python 2.7
-
-
-
-
-


### PR DESCRIPTION
I've extended the script to include more information taken from the dell warranty API. It includes the type of warranty and the contract_id it's registered under. Next to that the script will first find the dell hardware, and then start calling for the dell api. It won't filter out the dell hardware afterwards.

For the moment services like 'keep your harddrive' have been excluded from being registered in Device42, though it can be enabled by removing lines 117,118 and 119 in warranty_dell.py

Next to that paging (offset and limit) has been introduced and it does it in steps of 100 records.
