### PR TITLE
Introducing new features and some bugfixes

### DIFF
--- a/Files/shared.py
+++ b/Files/shared.py
@@ -163,7 +163,7 @@ class Device42rest:
         if DEBUG:
             print '\n[!] Fetching devices from Device42 with offset=' + str(offset)
         api_path = '/api/1.0/devices/all/'
-        cols = '?include_cols=serial_no,device_id,manufacturer&limit=100&offset=' + str(offset) + '&hardware=' + models
+        cols = '?include_cols=serial_no,device_id,manufacturer&limit=50&offset=' + str(offset) + '&hardware=' + models
         path = api_path + cols
         response = self.get_data(path)
         return response

--- a/Files/warranty_dell.py
+++ b/Files/warranty_dell.py
@@ -52,7 +52,7 @@ class Dell(WarrantyBase, object):
         inline_serials = ','.join(inline_serials)
 
         payload = {'id': inline_serials, 'apikey': self.api_key, 'accept': 'Application/json'}
-
+        
         try:
             resp = requests.get(self.url, params=payload, verify=True, timeout=timeout)
             msg = 'Status code: %s' % str(resp.status_code)
@@ -141,7 +141,7 @@ class Dell(WarrantyBase, object):
                         # Mention this to device42
 
                         service_level_group = sub_item['ServiceLevelGroup']
-                        if service_level_group == -1 or service_level_group == 5 or service_level_group == 8:
+                        if service_level_group == -1 or service_level_group == 5 or service_level_group == 8 or service_level_group == 99999:
                             contract_type = 'Warranty'
                         elif service_level_group == 8 and 'compellent' in product_id:
                             contract_type = 'Service'

--- a/Files/warranty_dell.py
+++ b/Files/warranty_dell.py
@@ -116,7 +116,10 @@ class Dell(WarrantyBase, object):
                     for sub_item in warranties:
                         data.clear()
                         ship_date = asset['ShipDate'].split('T')[0]
-                        product_id = product['ProductId']
+                        try:
+                            product_id = product['ProductId']
+                        except:
+                            product_id = 'notspecified'
 
                         data.update({'order_no': order_no})
                         if ship_date:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ In order for this script to check warranty status of the device, the device must
 - Dell's API key can be obtained by filling the on-boarding form. Please, follow the instructions from this ppt file: http://en.community.dell.com/dell-groups/supportapisgroup/m/mediagallery/20428185
 - HP's API key can be obtained by filling the on-boarding form. Please, follow the instructions from here: https://developers.hp.com/css-enroll
 
+## New Changes
+- Added section to also update systems which have had their serials numbers changed due to a life_cycle event.
+
 ## Changes
 - Moved from just showing last date to showing all warranties and services found in the api call
 - Comparison on existence of registration per purchase/support info (per line on the order) based on serial, line contract id and contract end date

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ In order for this script to check warranty status of the device, the device must
 
 ## New Changes
 - Added section to also update systems which have had their serials numbers changed due to a life_cycle event.
+- Using offset per 50 requests instead of 100. The Dell API seems to limit response to 80 serials. For every 100 requests no info came back for the last 20 serials.
+- Added a service_level_group for dell equipment as that also has warranty contracts
 
 ## Changes
 - Moved from just showing last date to showing all warranties and services found in the api call

--- a/starter.py
+++ b/starter.py
@@ -64,9 +64,9 @@ def loader(name, api, d42):
 
     # Locate the devices involved, based on the hardware models found, add offset with recursion
     offset = 0
-    serials = []
     previous_batch = None
     while True:
+        serials = []
         current_hardware_models = get_hardware_by_vendor(name)
         current_devices_batch = d42.get_devices(offset, current_hardware_models)
 

--- a/starter.py
+++ b/starter.py
@@ -87,8 +87,8 @@ def loader(name, api, d42):
                         print '[+] %s serial #: %s' % (name.title(), d42_serial)
                         # keep if statement in to prevent issues with vendors having choosen the same model names
                         # brief pause to let the API get a moment of rest and prevent errors
-                        time.sleep(1)
-                        serials.append(d42_serial)
+                        #time.sleep(1)
+                        serials.append(d42_serial.upper())
                 except ValueError as e:
                     print '\n[!] Error in item: "%s", msg : "%s"' % (item, e)
 

--- a/starter.py
+++ b/starter.py
@@ -100,7 +100,7 @@ def loader(name, api, d42):
                 if result is not None:
                     api.process_result(result, purchases)
 
-            offset += 100
+            offset += 50
         else:
             print '\n[!] Finished'
             break


### PR DESCRIPTION
it looked like the dell api only gave answer for up to 80 records at a time, so reduced the offset to 50 to be sure.
The offset increased the list of warranty checks to perform each offset increase. Moved the init of the array into the loop to clear previous list
Systems being decommissioned have had a epoch behind the serial number (don't see the reason for that being in the life_cycle event btw). The script now takes care of that and makes sure the warranty check is done against the actual serialnumber.