### PR TITLE
Don't choke on line items without end dates

### DIFF
--- a/starter.py
+++ b/starter.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
                     start = line_item.get('line_start_date')
                     devices = line_item.get('devices')
 
-                    if devices:
+                    if start and end and devices:
                         for device in devices:
                             if 'serial_no' in device:
                                 serial = device['serial_no']


### PR DESCRIPTION
If a line item is found that contains devices but does not contain both start and end dates, we should not abort with a TypeError when trying to build a key for the purchases dict.

Without this change, such line items result in

```
Traceback (most recent call last):
  File "/opt/device42/warranty_check/starter.py", line 135, in <module>
    hasher = serial + start + end
TypeError: coercing to Unicode: need string or buffer, NoneType found
```