### PR TITLE
Fix Lenovo lookup and catch errors

### DIFF
--- a/Files/warranty_ibm_lenovo.py
+++ b/Files/warranty_ibm_lenovo.py
@@ -79,15 +79,18 @@ class IbmLenovo(WarrantyBase, object):
             if current_product is not None:
 
                 resp = self.requests.post(
-                    self.url2 + '/' + current_product['ParentID'] + '?tabName=Warranty&beta=false',
+                    self.url2 + '/' + current_product['Id'] + '?tabName=Warranty&beta=false',
                     data={'SERIALNUMBERKEY': current_product['Serial']},
                     verify=True,
                     timeout=timeout
                 )
 
                 data_object = re.search(r"ds_warranties=(.*?});", resp.text)
-                json_object = json.loads(data_object.group(1))
-                result.append(json_object)
+                try:
+                    json_object = json.loads(data_object.group(1))
+                    result.append(json_object)
+                except ValueError:
+                    continue
 
         return result
 


### PR DESCRIPTION
It's currently necessary to make requests to a URL of the form:

```
…/Laptops-and-netbooks/ThinkPad-T-Series-laptops/ThinkPad-T430si/2353/9KU
```

rather than

```
…/Laptops-and-netbooks/ThinkPad-T-Series-laptops/ThinkPad-T430si/2353
```

The former is provided under the `Id` key in the response to the previous request.

Also, it's possible that the result will be `null`, rather than valid JSON. (This is currently the case when using the `ParentId` value instead of the `Id` value). To deal with this (and other potential related errors), a try/catch block around the `json.loads()` block is required.