### PR TITLE
Forcing purchase line updates after Service Type field extension to 64 chars

### DIFF
--- a/Files/shared.py
+++ b/Files/shared.py
@@ -163,7 +163,7 @@ class Device42rest:
         if DEBUG:
             print '\n[!] Fetching devices from Device42 with offset=' + str(offset)
         api_path = '/api/1.0/devices/all/'
-        cols = '?include_cols=serial_no,device_id,manufacturer&limit=100&offset=' + str(offset) + '&hardware=' + models
+        cols = '?include_cols=serial_no,device_id,manufacturer&limit=50&offset=' + str(offset) + '&hardware=' + models
         path = api_path + cols
         response = self.get_data(path)
         return response

--- a/Files/shared.py
+++ b/Files/shared.py
@@ -67,11 +67,13 @@ class Config:
         hp = self.cc.getboolean('discover', 'hp')
         ibm = self.cc.getboolean('discover', 'ibm')
         lenovo = self.cc.getboolean('discover', 'lenovo')
+        forcedupdate = self.cc.getboolean('discover', 'forcedupdate')
         return {
             'dell': dell,
             'hp': hp,
             'ibm': ibm,
-            'lenovo': lenovo
+            'lenovo': lenovo,
+            'forcedupdate': forcedupdate
         }
 
     def __get_dell_cfg(self):

--- a/Files/warranty.cfg.example
+++ b/Files/warranty.cfg.example
@@ -10,6 +10,7 @@ dell = True
 hp = True
 ibm = True
 lenovo = True
+forcedupdate = False
 
 [dell]
 # set api_key as provided by Dell

--- a/Files/warranty_dell.py
+++ b/Files/warranty_dell.py
@@ -52,7 +52,7 @@ class Dell(WarrantyBase, object):
         inline_serials = ','.join(inline_serials)
 
         payload = {'id': inline_serials, 'apikey': self.api_key, 'accept': 'Application/json'}
-
+        
         try:
             resp = requests.get(self.url, params=payload, verify=True, timeout=timeout)
             msg = 'Status code: %s' % str(resp.status_code)
@@ -141,7 +141,7 @@ class Dell(WarrantyBase, object):
                         # Mention this to device42
 
                         service_level_group = sub_item['ServiceLevelGroup']
-                        if service_level_group == -1 or service_level_group == 5 or service_level_group == 8:
+                        if service_level_group == -1 or service_level_group == 5 or service_level_group == 8 or service_level_group == 99999:
                             contract_type = 'Warranty'
                         elif service_level_group == 8 and 'compellent' in product_id:
                             contract_type = 'Service'

--- a/Files/warranty_dell.py
+++ b/Files/warranty_dell.py
@@ -116,7 +116,10 @@ class Dell(WarrantyBase, object):
                     for sub_item in warranties:
                         data.clear()
                         ship_date = asset['ShipDate'].split('T')[0]
-                        product_id = product['ProductId']
+                        try:
+                            product_id = product['ProductId']
+                        except:
+                            product_id = 'notspecified'
 
                         data.update({'order_no': order_no})
                         if ship_date:

--- a/Files/warranty_dell.py
+++ b/Files/warranty_dell.py
@@ -104,7 +104,6 @@ class Dell(WarrantyBase, object):
                     serial = asset['ServiceTag']
                     customernumber = asset['CustomerNumber']
                     country = asset['CountryLookupCode']
-                    ship_date = asset['ShipDate'].split('T')[0]
 
                     '''
                     For future implementation of registering the purchase date as a lifecycle event
@@ -119,6 +118,7 @@ class Dell(WarrantyBase, object):
                     # We need check per warranty service item
                     for sub_item in warranties:
                         data.clear()
+                        ship_date = asset['ShipDate'].split('T')[0]
                         try:
                             product_id = product['ProductId']
                         except:

--- a/Files/warranty_hp.py
+++ b/Files/warranty_hp.py
@@ -199,9 +199,8 @@ class Hp(WarrantyBase, object):
             data.update({'line_contract_type': item['type']})
 
             try:
-                # There's a max 32 character limit
-                # on the line service type field in Device42 (version 10.2.1)
-                service_level_description = left(item['serviceLevel'], 32)
+                # There's a max 64 character limit on the line service type field in Device42 (version 13.1.0)
+                service_level_description = left(sub_item['ServiceLevelDescription'], 64)
                 data.update({'line_service_type': service_level_description})
             except:
                 pass

--- a/Files/warranty_ibm_lenovo.py
+++ b/Files/warranty_ibm_lenovo.py
@@ -145,9 +145,8 @@ class IbmLenovo(WarrantyBase, object):
                 data.update({'line_contract_type': warranty['Origin']})
 
                 try:
-                    # There's a max 32 character limit
-                    # on the line service type field in Device42 (version 10.2.1)
-                    service_level_description = left(warranty['WarrentyType'], 32)
+                    # There's a max 64 character limit on the line service type field in Device42 (version 13.1.0)
+                    service_level_description = left(sub_item['ServiceLevelDescription'], 64)
                     data.update({'line_service_type': service_level_description})
                 except:
                     pass

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ In order for this script to check warranty status of the device, the device must
 - Dell's API key can be obtained by filling the on-boarding form. Please, follow the instructions from this ppt file: http://en.community.dell.com/dell-groups/supportapisgroup/m/mediagallery/20428185
 - HP's API key can be obtained by filling the on-boarding form. Please, follow the instructions from here: https://developers.hp.com/css-enroll
 
+## New Changes
+- Added section to also update systems which have had their serials numbers changed due to a life_cycle event.
+
 ## Changes
 - Moved from just showing last date to showing all warranties and services found in the api call
 - Comparison on existence of registration per purchase/support info (per line on the order) based on serial, line contract id and contract end date

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ In order for this script to check warranty status of the device, the device must
 
 ## New Changes
 - Added section to also update systems which have had their serials numbers changed due to a life_cycle event.
+- Using offset per 50 requests instead of 100. The Dell API seems to limit response to 80 serials. For every 100 requests no info came back for the last 20 serials.
+- Added a service_level_group for dell equipment as that also has warranty contracts
 
 ## Changes
 - Moved from just showing last date to showing all warranties and services found in the api call

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ In order for this script to check warranty status of the device, the device must
 - HP's API key can be obtained by filling the on-boarding form. Please, follow the instructions from here: https://developers.hp.com/css-enroll
 
 ## New Changes
-- Added section to also update systems which have had their serials numbers changed due to a life_cycle event.
-- Using offset per 50 requests instead of 100. The Dell API seems to limit response to 80 serials. For every 100 requests no info came back for the last 20 serials.
-- Added a service_level_group for dell equipment as that also has warranty contracts
+- service type field has been extended in version 13.1.0.
+- Added an option to force updating the line items (currently only works for Dell). Needed as the Service Type does not get updated otherwise as the contents of the field can't be checked via the api to see if it needs a change.
+
 
 ## Changes
 - Moved from just showing last date to showing all warranties and services found in the api call
@@ -25,6 +25,9 @@ In order for this script to check warranty status of the device, the device must
 - Using offset per 100 requests instead of doing a full request of all devices
 - Brief pause per api call to prevent blockage at the api request site (1 second pause per api call)
 - Making a remark if the session for the api call is unauthorized (http code 401)
+- Added section to also update systems which have had their serials numbers changed due to a life_cycle event.
+- Using offset per 50 requests instead of 100. The Dell API seems to limit response to 80 serials. For every 100 requests no info came back for the last 20 serials.
+- Added a service_level_group for dell equipment as that also has warranty contracts
 
 ## Plans
 - Include life_cycle event to register the purchase date. Unfortunately it can’t can done now, as I can’t easily compare purchases with the information found at dell. The life_cycle event doesn’t give back the serial, only the devicename. It would be nice if the serial_no could be added to the output of GET /api/1.0/lifecycle_event/
@@ -32,6 +35,7 @@ In order for this script to check warranty status of the device, the device must
 ## Gotchas
 If either hardware model or serial # is missing, warranty status won't be checked for device.
 HP script unstable, may require retries.
+IBM script points to warranty info not related to the SKU, serial given
 
 ## Usage
 Set required parameters in warranty.cfg file and run warranty_dell.py script:

--- a/starter.py
+++ b/starter.py
@@ -64,9 +64,9 @@ def loader(name, api, d42):
 
     # Locate the devices involved, based on the hardware models found, add offset with recursion
     offset = 0
-    serials = []
     previous_batch = None
     while True:
+        serials = []
         current_hardware_models = get_hardware_by_vendor(name)
         current_devices_batch = d42.get_devices(offset, current_hardware_models)
 

--- a/starter.py
+++ b/starter.py
@@ -87,8 +87,8 @@ def loader(name, api, d42):
                         print '[+] %s serial #: %s' % (name.title(), d42_serial)
                         # keep if statement in to prevent issues with vendors having choosen the same model names
                         # brief pause to let the API get a moment of rest and prevent errors
-                        time.sleep(1)
-                        serials.append(d42_serial)
+                        #time.sleep(1)
+                        serials.append(d42_serial.upper())
                 except ValueError as e:
                     print '\n[!] Error in item: "%s", msg : "%s"' % (item, e)
 

--- a/starter.py
+++ b/starter.py
@@ -100,7 +100,7 @@ def loader(name, api, d42):
                 if result is not None:
                     api.process_result(result, purchases)
 
-            offset += 100
+            offset += 50
         else:
             print '\n[!] Finished'
             break

--- a/starter.py
+++ b/starter.py
@@ -117,22 +117,28 @@ if __name__ == '__main__':
     # get purchases data from Device42
     orders = d42_rest.get_purchases()
     purchases = {}
+    #forcedupdate = False
 
     if orders and 'purchases' in orders:
         for order in orders['purchases']:
             if 'line_items' in order:
-                for line_item in order['line_items']:
-                    end = line_item.get('line_end_date')
-                    start = line_item.get('line_start_date')
-                    devices = line_item.get('devices')
+                purchase_id = order.get('purchase_id')
+                order_no = order.get('order_no')
 
-                    if start and end and devices:
+                for line_item in order['line_items']:
+                    line_no = line_item.get('line_no')
+                    devices = line_item.get('devices')
+                    contractid = line_item.get('line_notes')
+                    start = line_item.get('line_start_date')
+                    end = line_item.get('line_end_date')
+
+                    if start and end and devices and contractid:
                         for device in devices:
                             if 'serial_no' in device:
                                 serial = device['serial_no']
-                                hasher = serial + start + end
+                                hasher = serial + contractid + start + end
                                 if hasher not in purchases:
-                                    purchases[serial + start + end] = [start, end]
+                                    purchases[hasher] = [purchase_id, order_no, line_no, contractid, start, end, discover['forcedupdate']]
 
     APPS_ROW = []
     if discover['dell']:


### PR DESCRIPTION
As the service type field now is extended to 64 chars (version 13.1.0) I've updated the code to support that. unfortunately the API call to Device42 doesn't give back the service type content field, therefore the information will never be updated if the end date of the service contract doesn't change.

Therefore introduced storing the contract and line_no in the purchases dictionary as well. In combination with the forcedupdate option in the config one can now push to have all registrations updated.

This works well in Dell, but I have not been able to test for HP (pending API access) and IBM (getting wrong information back from the API).