### PR TITLE
D42-14544

### DIFF
--- a/Files/shared.py
+++ b/Files/shared.py
@@ -78,6 +78,17 @@ class Config:
             'forcedupdate': forcedupdate
         }
 
+    def __get_cisco_cfg(self):
+        # Cisco ---------------------------------------------
+        cisco_url = self.cc.get('cisco', 'url')
+        cisco_client_id = self.cc.get('cisco', 'client_id')
+        cisco_client_secret = self.cc.get('cisco', 'client_secret')
+        return {
+            'url': cisco_url,
+            'client_id': cisco_client_id,
+            'client_secret': cisco_client_secret
+        }
+
     def __get_dell_cfg(self):
         # Dell ---------------------------------------------
         dell_url = self.cc.get('dell', 'url')

--- a/Files/shared.py
+++ b/Files/shared.py
@@ -34,6 +34,8 @@ class Config:
             res = self.__get_d42_cfg()
         elif source == 'discover':
             res = self.__get_discover_cfg()
+        elif source == 'cisco':
+            res = self.__get_cisco_cfg()
         elif source == 'dell':
             res = self.__get_dell_cfg()
         elif source == 'hp':
@@ -63,6 +65,7 @@ class Config:
 
     def __get_discover_cfg(self):
         # Discover -----------------------------------------
+        cisco = self.cc.getboolean('discover', 'cisco')
         dell = self.cc.getboolean('discover', 'dell')
         hp = self.cc.getboolean('discover', 'hp')
         ibm = self.cc.getboolean('discover', 'ibm')
@@ -70,6 +73,7 @@ class Config:
         meraki = self.cc.getboolean('discover', 'meraki')
         forcedupdate = self.cc.getboolean('discover', 'forcedupdate')
         return {
+            'cisco': cisco,
             'dell': dell,
             'hp': hp,
             'ibm': ibm,

--- a/Files/warranty.cfg.example
+++ b/Files/warranty.cfg.example
@@ -13,6 +13,12 @@ lenovo = True
 meraki = True
 forcedupdate = False
 
+[cisco]
+# set the client_id and client_secret provided by Cisco
+client_id =
+client_secret =
+url =
+
 [dell]
 # set api_key as provided by Dell
 client_id =

--- a/Files/warranty.cfg.example
+++ b/Files/warranty.cfg.example
@@ -17,7 +17,7 @@ forcedupdate = False
 # set the client_id and client_secret provided by Cisco
 client_id =
 client_secret =
-url =
+url = https://api.cisco.com/sn2info/v2/coverage/summary/serial_numbers
 
 [dell]
 # set api_key as provided by Dell

--- a/Files/warranty.cfg.example
+++ b/Files/warranty.cfg.example
@@ -6,10 +6,10 @@ url =
 
 [discover]
 # enable/disable discoveries
-cisco = False
-dell = False
-hp = False
-ibm = False
+cisco = True
+dell = True
+hp = True
+ibm = True
 lenovo = False
 meraki = False
 forcedupdate = False

--- a/Files/warranty.cfg.example
+++ b/Files/warranty.cfg.example
@@ -10,8 +10,8 @@ cisco = True
 dell = True
 hp = True
 ibm = True
-lenovo = False
-meraki = False
+lenovo = True
+meraki = True
 forcedupdate = False
 
 [cisco]

--- a/Files/warranty.cfg.example
+++ b/Files/warranty.cfg.example
@@ -6,7 +6,7 @@ url =
 
 [discover]
 # enable/disable discoveries
-cisco = True
+cisco = False
 dell = False
 hp = False
 ibm = False

--- a/Files/warranty.cfg.example
+++ b/Files/warranty.cfg.example
@@ -6,11 +6,12 @@ url =
 
 [discover]
 # enable/disable discoveries
-dell = True
-hp = True
-ibm = True
-lenovo = True
-meraki = True
+cisco = True
+dell = False
+hp = False
+ibm = False
+lenovo = False
+meraki = False
 forcedupdate = False
 
 [cisco]

--- a/Files/warranty_cisco.py
+++ b/Files/warranty_cisco.py
@@ -5,13 +5,16 @@ import random
 import requests
 from datetime import datetime, timedelta
 
-from shared import DEBUG, RETRY, ORDER_NO_TYPE, left
+from shared import DEBUG, RETRY, ORDER_NO_TYPE, left, Device42rest
 from warranty_abstract import WarrantyBase
 
 try:
     requests.packages.urllib3.disable_warnings()
 except:
     pass
+
+full_serials = {'SAL09232Q0Z': 'SAL09232Q0Z', '32964768': '32964768', 'SWCAT1239A0CJ': 'SWCAT1239A0CJ',
+                'FOC0903N5J9': 'FOC0903N5J9', 'INM07501EC3': 'INM07501EC3', }
 
 
 class Cisco(WarrantyBase, object):
@@ -34,8 +37,7 @@ class Cisco(WarrantyBase, object):
         self.expires_at = None
         self.access_token = None
 
-        # OAth 2.0
-
+    # OAth 2.0
     def get_access_token(self, client_id, client_secret):
         access_token_request_url = "https://cloudsso.cisco.com/as/token.oauth2"
 
@@ -149,72 +151,70 @@ class Cisco(WarrantyBase, object):
                     else:
                         order_no = self.generate_random_order_no()
 
-                    serial = device['parent_sr_no']
+                    serial = device['sr_no']
 
-                    if "orderable_pid_list" in device:
-                        for orderable_item in device["orderable_pid_list"]:
-                            data.clear()
+                    data.clear()
 
-                            data.update({'order_no': order_no})
-                            data.update({'completed': 'yes'})
+                    data.update({'order_no': order_no})
+                    data.update({'completed': 'yes'})
 
-                            data.update({'vendor': 'Cisco'})
-                            data.update({'line_device_serial_nos': full_serials[serial]})
-                            data.update({'line_type': 'contract'})
-                            data.update({'line_item_type': 'device'})
-                            data.update({'line_completed': 'yes'})
+                    data.update({'vendor': 'Cisco'})
+                    data.update({'line_device_serial_nos': full_serials[serial]})
+                    data.update({'line_type': 'contract'})
+                    data.update({'line_item_type': 'device'})
+                    data.update({'line_completed': 'yes'})
 
-                            try:
-                                line_contract_id = orderable_item['service_contract_number']
-                            except KeyError:
-                                line_contract_id = "Not Available"
+                    try:
+                        line_contract_id = device['service_contract_number']
+                    except KeyError:
+                        line_contract_id = "Not Available"
 
-                            data.update({'line_notes': line_contract_id})
-                            data.update({'line_contract_id': line_contract_id})
+                    data.update({'line_notes': line_contract_id})
+                    data.update({'line_contract_id': line_contract_id})
 
-                            try:
-                                warranty_type = orderable_item['warranty_type']
-                            except KeyError:
-                                warranty_type = "Service"
+                    try:
+                        warranty_type = device['warranty_type']
+                    except KeyError:
+                        warranty_type = "Service"
 
-                            data.update({'line_contract_type': warranty_type})
+                    data.update({'line_contract_type': warranty_type})
 
-                            if warranty_type == 'Service':
-                                # Skipping the services, only want the warranties
-                                continue
+                    if warranty_type == 'Service':
+                        # Skipping the services, only want the warranties
+                        continue
 
-                            try:
-                                # max 64 character limit on the line service type field in Device42 (version 13.1.0)
-                                service_line_description = left(orderable_item['service_line_descr'], 64)
-                                data.update({'line_service_type': service_line_description})
-                            except KeyError:
-                                pass
+                    try:
+                        # max 64 character limit on the line service type field in Device42 (version 13.1.0)
+                        service_line_description = left(device['service_line_descr'], 64)
+                        data.update({'line_service_type': service_line_description})
+                    except KeyError:
+                        pass
 
-                            start_date = "2019-01-01"
-                            end_date = orderable_item['warranty_end_date']
-                            data.update({'line_end_date': end_date})
+                    start_date = "2019-01-01"
+                    end_date = device['warranty_end_date']
+                    data.update({'line_end_date': end_date})
 
-                            # Compare warranty dates by serial, contract_id, start date and end date
-                            # Start date is not provided in request response so the date is simply used for hasher
-                            hasher = serial + line_contract_id + start_date + end_date
+                    # Compare warranty dates by serial, contract_id, start date and end date
+                    # Start date is not provided in request response so the date is simply used for hasher
+                    hasher = serial + line_contract_id + start_date + end_date
 
-                            try:
-                                d_purchase_id, d_order_no, d_line_no, d_contractid, d_start, d_end, forcedupdate = \
-                                    purchases[hasher]
+                    try:
+                        d_purchase_id, d_order_no, d_line_no, d_contractid, d_start, d_end, forcedupdate = \
+                            purchases[hasher]
 
-                                if forcedupdate:
-                                    data['purchase_id'] = d_purchase_id
-                                    data.pop('order_no')
-                                    raise KeyError
+                        if forcedupdate:
+                            data['purchase_id'] = d_purchase_id
+                            data.pop('order_no')
+                            raise KeyError
 
-                                # check for duplicate state
-                                if d_contractid == line_contract_id and d_start == start_date and d_end == end_date:
-                                    print '\t[!] Duplicate found. Purchase ' \
-                                          'for SKU "%s" and "%s" with end date "%s" ' \
-                                          'order_id: %s and line_no: %s' % (
-                                              serial, line_contract_id, end_date, d_purchase_id, d_line_no)
-                            except KeyError:
-                                raise KeyError
+                        # check for duplicate state
+                        if d_contractid == line_contract_id and d_start == start_date and d_end == end_date:
+                            print '\t[!] Duplicate found. Purchase ' \
+                                  'for SKU "%s" and "%s" with end date "%s" ' \
+                                  'order_id: %s and line_no: %s' % (
+                                      serial, line_contract_id, end_date, d_purchase_id, d_line_no)
+                    except KeyError:
+                        raise KeyError
 
                 except KeyError:
                     self.d42_rest.upload_data(data)

--- a/Files/warranty_cisco.py
+++ b/Files/warranty_cisco.py
@@ -1,0 +1,118 @@
+import json
+import sys
+import time
+import random
+import requests
+from datetime import datetime, timedelta
+
+from shared import DEBUG, RETRY, ORDER_NO_TYPE, left
+from warranty_abstract import WarrantyBase
+
+try:
+    requests.packages.urllib3.disable_warnings()
+except:
+    pass
+
+#https://cloudsso.cisco.com/as/token.oauth2
+
+
+class Cisco(WarrantyBase, object):
+
+    def __init__(self, params):
+        super(Cisco, self).__init__()
+        self.url = params['url']
+        self.client_id = params['client_id']
+        self.client_secret = params['client_secret']
+        self.debug = DEBUG
+        self.retry = RETRY
+        self.order_no = ORDER_NO_TYPE
+        self.d42_rest = params['d42_rest']
+        self.common = None
+
+        if self.order_no == 'common':
+            self.common = self.generate_random_order_no()
+
+        # OAuth 2.0
+        self.expires_at = None
+        self.access_token = None
+
+        # OAth 2.0
+
+    def get_access_token(self, client_id, client_secret):
+        access_token_request_url = "https://cloudsso.cisco.com/as/token.oauth2"
+
+        timeout = 10
+
+        payload = {
+            'client_id': client_id,
+            'client_secret': client_secret,
+            'grant_type': 'client_credentials'
+        }
+
+        try:
+            resp = requests.post(access_token_request_url, data=payload, timeout=timeout)
+
+            msg = 'Status code: %s' % str(resp.status_code)
+
+            if str(resp.status_code) == '400' or str(resp.status_code) == '401' or str(resp.status_code) == '404':
+                print 'HTTP error. Message was: %s' % msg
+            elif str(resp.status_code) == '500':
+                print 'HTTP error. Message was: %s' % msg
+                print 'token access services may be down, try again later...'
+                print resp.text
+            else:
+                # assign access token and expiration to instance variables
+                result = resp.json()
+                self.access_token = "Bearer " + str(result['access_token'])
+                self.expires_at = datetime.utcnow() + timedelta(seconds=int(result['expires_in']))
+                if self.debug > 1:
+                    print "Request Token Acquired"
+        except requests.RequestException as e:
+            self.error_msg(e)
+
+    def run_warranty_check(self, inline_serials, retry=True):
+        global full_serials
+        full_serials = {}
+
+        if self.debug:
+            print '\t[+] Checking warranty info for "%s"' % inline_serials
+        timeout = 10
+
+        # making sure the warranty also gets updated if the serial has been changed by decom lifecycle process
+        incoming_serials = inline_serials.split(',')
+        inline_serials = []
+
+        for d42_serial in incoming_serials:
+            d42_serial = d42_serial.upper()
+            if '_' in d42_serial:
+                full_serials.update({d42_serial.split('_')[0]: d42_serial})
+                d42_serial = d42_serial.split('_')[0]
+            elif '(' in d42_serial:
+                full_serials.update({d42_serial.split('(')[0]: d42_serial})
+                d42_serial = d42_serial.split('(')[0]
+            else:
+                full_serials.update({d42_serial: d42_serial})
+            inline_serials.append(d42_serial)
+        inline_serials = ','.join(inline_serials)
+
+        # check to see if the access token is expired, if it is get a new one, else, continue
+        if self.expires_at is None or self.expires_at is not None and self.expires_at <= datetime.utcnow():
+            if self.debug > 1:
+                print 'attempting to acquire access_token'
+
+            self.get_access_token(self.client_id, self.client_secret)
+
+        if self.access_token is None:
+            if self.debug > 1:
+                print 'unable to acquire access_token'
+            return None
+
+        # get the device information using the requested access token
+
+
+
+
+    def process_result(self, result, purchases):
+        pass
+
+

--- a/Files/warranty_cisco.py
+++ b/Files/warranty_cisco.py
@@ -187,7 +187,7 @@ class Cisco(WarrantyBase, object):
                     except KeyError:
                         pass
 
-                    start_date = "2019-01-01"
+                    start_date = "0001-01-01"
                     end_date = device['warranty_end_date']
                     data.update({'line_end_date': end_date})
 

--- a/Files/warranty_cisco.py
+++ b/Files/warranty_cisco.py
@@ -5,16 +5,13 @@ import random
 import requests
 from datetime import datetime, timedelta
 
-from shared import DEBUG, RETRY, ORDER_NO_TYPE, left, Device42rest
+from shared import DEBUG, RETRY, ORDER_NO_TYPE, left
 from warranty_abstract import WarrantyBase
 
 try:
     requests.packages.urllib3.disable_warnings()
 except:
     pass
-
-full_serials = {'SAL09232Q0Z': 'SAL09232Q0Z', '32964768': '32964768', 'SWCAT1239A0CJ': 'SWCAT1239A0CJ',
-                'FOC0903N5J9': 'FOC0903N5J9', 'INM07501EC3': 'INM07501EC3', }
 
 
 class Cisco(WarrantyBase, object):

--- a/Files/warranty_dell.py
+++ b/Files/warranty_dell.py
@@ -201,8 +201,10 @@ class Dell(WarrantyBase, object):
                         if sub_item['serviceLevelDescription'] is not None:
                             if 'Parts' in sub_item['serviceLevelDescription'] or 'Onsite' in sub_item['serviceLevelDescription']:
                                 contract_type = 'Warranty'
-                        else:  # no useful information, continue to next entitlement item
+                        else:  # service level description is null, continue to next entitlement item
                             continue
+                    else:  # service level description not listed in entitlement, continue to next item
+                        continue
 
                     data.update({'line_contract_type': contract_type})
 

--- a/Files/warranty_dell.py
+++ b/Files/warranty_dell.py
@@ -195,23 +195,16 @@ class Dell(WarrantyBase, object):
                     # so notes is now used for identification
                     # Mention this to device42
 
-                    if 'serviceLevelGroup' in sub_item:
-                        service_level_group = sub_item['serviceLevelGroup']
-                    else:
-                        service_level_group = None
+                    contract_type = 'Service'  # default contract type
 
-                    if service_level_group == -1 or service_level_group == 5 or service_level_group == 8 or service_level_group == 99999:
-                        contract_type = 'Warranty'
-                    elif service_level_group == 11 and 'compellent' in product_id:
-                        contract_type = 'Warranty'
-                    else:
-                        contract_type = 'Service'
+                    if 'serviceLevelDescription' in sub_item:
+                        if sub_item['serviceLevelDescription'] is not None:
+                            if 'Parts' in sub_item['serviceLevelDescription'] or 'Onsite' in sub_item['serviceLevelDescription']:
+                                contract_type = 'Warranty'
+                        else:  # no useful information, continue to next entitlement item
+                            continue
 
                     data.update({'line_contract_type': contract_type})
-
-                    if contract_type == 'Service':
-                        # Skipping the services, only want the warranties
-                        continue
 
                     try:
                         # There's a max 64 character limit on the line service type field in Device42 (version 13.1.0)

--- a/Files/warranty_dell.py
+++ b/Files/warranty_dell.py
@@ -38,7 +38,7 @@ class Dell(WarrantyBase, object):
     def get_access_token(self, client_id, client_secret):
         access_token_request_url = "https://apigtwb2c.us.dell.com/auth/oauth/v2/token"
 
-        timeout = 10
+        timeout = 60
 
         payload = {
             'client_id': client_id,
@@ -72,7 +72,7 @@ class Dell(WarrantyBase, object):
 
         if self.debug:
             print '\t[+] Checking warranty info for "%s"' % inline_serials
-        timeout = 10
+        timeout = 60
 
         # making sure the warranty also gets updated if the serial has been changed by decom lifecycle process
         incoming_serials = inline_serials.split(',')

--- a/Files/warranty_meraki.py
+++ b/Files/warranty_meraki.py
@@ -100,8 +100,7 @@ class Meraki(WarrantyBase, object):
 
                 all_data.append(copy.deepcopy(data))
 
-                # Easter Egg: start date in hash is the year meraki was founded
-                hasher = serial_number + "2006-01-01" + license_expiration
+                hasher = serial_number + "0001-01-01" + license_expiration
 
                 try:
                     d_purchase_id, d_order_no, d_line_no, d_contractid, d_start, d_end, forcedupdate = purchases[hasher]
@@ -112,7 +111,7 @@ class Meraki(WarrantyBase, object):
                         raise KeyError
 
                     # check for duplicate state
-                    if d_start == "2006-01-01" and d_end == license_expiration:
+                    if d_start == "0001-01-01" and d_end == license_expiration:
                         print '\t[!] Duplicate found. Purchase ' \
                               'for SKU "%s" with end date "%s" ' \
                               'is already uploaded' % (serial_number, license_expiration)
@@ -206,7 +205,7 @@ class Meraki(WarrantyBase, object):
                 if result['expirationDate'] == "N/A":
                     days_remaining = datetime.utcnow().strftime("%Y-%m-%d")
                 else:
-                    days_remaining = self.meraki_date_parser(result['expirationDate'])  # TODO make sure this works
+                    days_remaining = self.meraki_date_parser(result['expirationDate'])
 
                 all_license_states[organization_id] = days_remaining
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ In order for this script to check warranty status of the device, the device must
 - IBM script points to warranty info not related to the SKU, serial given
 - If a Meraki product has a licence with a renewal required state, the expiration date will be set to the current date
 
+## Change Log
+
 ## Usage
 - Set required parameters in warranty.cfg file and run starter.py script:
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This script checks warranty status for Dell, HP, IBM, Lenovo and Meraki manufact
 
 ## Prerequisites
 In order for this script to check warranty status of the device, the device must have hardware model and serial number entered in Device42. Dell Warranty Status API key must be acquired as well.
-- Device42 Hardware model must have "Dell", "Hewlett Packard", "IBM", "LENOVO" or "Meraki" in it's manufacturer data.
-- Device42 Serial number must be set to "Dell", "Hewlett Packard", "IBM", "LENOVO" or "Meraki" device serial number.
+- Device42 Hardware model must have "Cisco", "Dell", "Hewlett Packard", "IBM", "LENOVO" or "Meraki" in it's manufacturer data.
+- Device42 Serial number must be set to "Cisco", "Dell", "Hewlett Packard", "IBM", "LENOVO" or "Meraki" device serial number.
+- Cisco's client id and client secret can be obtained by completing their on-boarding form. Please follow the instructions from here: https://www.cisco.com/c/en/us/support/docs/services/sntc/onboarding_guide.html instructions for enabling the Cisco support APIs can be found here: https://apiconsole.cisco.com/documentation
 - Dell's client id and client secret can be obtained by filling the on-boarding form. New and existing API users will need to register an account with TechDirect. Please check: http://en.community.dell.com/dell-groups/supportapisgroup/
 - HP's API key can be obtained by filling the on-boarding form. Please, follow the instructions from here: https://developers.hp.com/css-enroll
 - Merakis API key can be obtained by going to the organization > settings page on the Meraki dashboard. Ensure that the enable access to API checkbox is selected then go to your profile to generate the API key. Please check https://developer.cisco.com/meraki/api/#/rest/getting-started/what-can-the-api-be-used-for
@@ -20,9 +21,6 @@ In order for this script to check warranty status of the device, the device must
 - If either hardware model or serial # is missing, warranty status won't be checked for device.
 - IBM script points to warranty info not related to the SKU, serial given
 - If a Meraki product has a licence with a renewal required state, the expiration date will be set to the current date
-
-## Change Log
-- Please check `CHANGELOG.md`
 
 ## Usage
 - Set required parameters in warranty.cfg file and run starter.py script:

--- a/starter.py
+++ b/starter.py
@@ -149,10 +149,11 @@ if __name__ == '__main__':
                     line_no = line_item.get('line_no')
                     devices = line_item.get('devices')
                     contractid = line_item.get('line_notes')
-                    start = line_item.get('line_start_date')
-                    end = line_item.get('line_end_date')
+                    # POs with no start and end dates will now be included and given a hasher key with date min and max
+                    start = line_item.get('line_start_date') if line_item.get('line_start_date') is not None else '0001-01-01'
+                    end = line_item.get('line_end_date') if line_item.get('line_end_date') is not None else '9999-12-31'
 
-                    if start and end and devices:
+                    if devices:
                         for device in devices:
                             if 'serial_no' in device:
                                 serial = device['serial_no']

--- a/starter.py
+++ b/starter.py
@@ -150,10 +150,10 @@ if __name__ == '__main__':
                     devices = line_item.get('devices')
                     contractid = line_item.get('line_notes')
                     # POs with no start and end dates will now be included and given a hasher key with date min and max
-                    start = line_item.get('line_start_date') if line_item.get('line_start_date') is not None else '0001-01-01'
-                    end = line_item.get('line_end_date') if line_item.get('line_end_date') is not None else '9999-12-31'
+                    start = line_item.get('line_start_date')
+                    end = line_item.get('line_end_date')
 
-                    if devices:
+                    if start and end and devices:
                         for device in devices:
                             if 'serial_no' in device:
                                 serial = device['serial_no']

--- a/starter.py
+++ b/starter.py
@@ -2,10 +2,12 @@
 import sys
 
 from Files.shared import Config, Device42rest
+from Files.warranty_cisco import Cisco
 from Files.warranty_dell import Dell
 from Files.warranty_hp import Hp
 from Files.warranty_ibm_lenovo import IbmLenovo
 from Files.warranty_meraki import Meraki
+
 
 def get_hardware_by_vendor(name):
     # Getting the hardware models, so we specifically target the manufacturer systems registered
@@ -29,7 +31,16 @@ def get_vendor_api(name):
     current_cfg = cfg.get_config(name)
     api = None
 
-    if vendor == 'dell':
+    if vendor == 'cisco':
+        cisco_params = {
+            'url': current_cfg['url'],
+            'client_id': current_cfg['client_id'],
+            'client_secret': current_cfg['client_secret'],
+            'd42_rest': d42_rest
+        }
+        api = Cisco(cisco_params)
+
+    elif vendor == 'dell':
         dell_params = {
             'url': current_cfg['url'],
             'client_id': current_cfg['client_id'],
@@ -150,6 +161,8 @@ if __name__ == '__main__':
                                     purchases[hasher] = [purchase_id, order_no, line_no, contractid, start, end, discover['forcedupdate']]
 
     APPS_ROW = []
+    if discover['cisco']:
+        APPS_ROW.append('cisco')
     if discover['dell']:
         APPS_ROW.append('dell')
     if discover['hp']:


### PR DESCRIPTION
- Cisco Support (untested)

- Dell Warranty bug fix, devices that have warranty items without start and end dates will now be included in purchases. This fixes a bug where the script would fail on splitting a none time object due to Dell warranty API returning warranty items with missing start dates

- Modified hasher function so that line items for a purchase that do not have a start and end date are still returned to check for duplicates. any devices returned will use a max and min date to create the hash