### PR TITLE
added a default start date for line items. also changed the config fi…

### DIFF
--- a/Files/warranty.cfg.example
+++ b/Files/warranty.cfg.example
@@ -53,4 +53,4 @@ retry = 3
 #	1. vendor   - order number is returned from vendor ( only for Dell )
 #	2. common   - order number is randomly generated and same for all purchases
 #	3. descrete - order number is randomly generated and uniqe for every purchase
-order_no_type = vendor
+order_no_type = common

--- a/Files/warranty_meraki.py
+++ b/Files/warranty_meraki.py
@@ -85,6 +85,8 @@ class Meraki(WarrantyBase, object):
                 else:
                     order_no = self.generate_random_order_no()
 
+                stripped_serial_no = str(serial_number).replace('-', '').strip()
+
                 data.update({'order_no': order_no})
                 data.update({'completed': 'yes'})
                 data.update({'vendor': 'Meraki'})
@@ -93,9 +95,13 @@ class Meraki(WarrantyBase, object):
                 data.update({'line_item_type': 'device'})
                 data.update({'line_completed': 'yes'})
 
+                data.update({'line_notes': stripped_serial_no})
+                data.update({'line_contract_id': stripped_serial_no})
+
                 # warranty - Note: Meraki product warranties are a combined average so there is no way of knowing start
                 # date for a particular device
                 data.update({'line_contract_type': 'Warranty'})
+                data.update({'line_start_date': "0001-01-01"})
                 data.update({'line_end_date': license_expiration})
 
                 all_data.append(copy.deepcopy(data))


### PR DESCRIPTION
- prevent duplicate POs from being created when the script is run for Meraki warranty sync

- changed default config file to common order type since most of the vendors do not use this type and it will cause POs to be created for each device