### PR TITLE
remove HP from check list

### DIFF
--- a/Files/warranty.cfg.example
+++ b/Files/warranty.cfg.example
@@ -8,7 +8,6 @@ url =
 # enable/disable discoveries
 cisco = True
 dell = True
-hp = True
 ibm = True
 lenovo = True
 meraki = True
@@ -25,12 +24,6 @@ url = https://api.cisco.com/sn2info/v2/coverage/summary/serial_numbers
 client_id =
 client_secret =
 url = https://apigtwb2c.us.dell.com/PROD/sbil/eapi/v5/asset-entitlements
-
-[hp]
-# set api_key as provided by HP
-api_key =
-api_secret =
-url = https://css.api.hp.com
 
 [ibm]
 url = http://support.lenovo.com/services/us/en/ContentService/GetProducts


### PR DESCRIPTION
Remove HP from the script because it's no longer supported.

![CleanShot 2023-10-01 at 13 59 24](https://github.com/device42/warranty_check/assets/98525884/ff537f74-62f8-41de-8719-64c4683be798)
